### PR TITLE
Mvh/2 1 schemas

### DIFF
--- a/v2/2_0/examples/text_translation_maximal_metadata_2_0.xml
+++ b/v2/2_0/examples/text_translation_maximal_metadata_2_0.xml
@@ -122,13 +122,15 @@
   </names>
   <source>
     <canonicalContent>
-      <book code="MAT" />
-      <book code="MRK" />
-      <book code="LUK" />
-      <book code="JHN" />
-      <book code="ACT" />
+      <book code="MAT"/>
+      <book code="MRK"/>
+      <book code="LUK"/>
+      <book code="JHN"/>
+      <book code="ACT"/>
     </canonicalContent>
-    <content name="zippy" src="sources/aSourceArchive.zip" role="sourceZip"/>
+    <structure>
+      <content name="zippy" src="sources/aSourceArchive.zip" role="sourceZip"/>
+    </structure>
   </source>
   <copyright>
     <fullStatement>

--- a/v2/2_1/schema/metadata.sch
+++ b/v2/2_1/schema/metadata.sch
@@ -30,4 +30,12 @@
             </sch:assert>
         </sch:rule>
     </sch:pattern>
+    <sch:pattern>
+        <sch:rule context="canonicalContent/book">
+            <sch:let name="bookCode" value="@code"/>
+            <sch:assert test="count(preceding-sibling::*[@code = $bookCode]) = 0">
+                <sch:value-of select="count(preceding-sibling::*[@code = $bookCode])"/> previous occurence(s) of book code '<sch:value-of select="@code"/>' in canonicalContent
+            </sch:assert>
+       </sch:rule>
+    </sch:pattern>
 </sch:schema>


### PR DESCRIPTION
This is as far as I can get with Schematron and XSLT 1. To check the mapping between manifest and publication I think I'd need to flatten the manifest before validation. But this does catch several categories of error that cannot be checked with RNG or XSD 1.0.